### PR TITLE
[FEATURE] Add create comment result filter

### DIFF
--- a/wp-webhooks-comments.php
+++ b/wp-webhooks-comments.php
@@ -1324,6 +1324,7 @@ $return_args = array(
 				}
 
 				if( $is_valid ){
+					$data_array = apply_filters( 'wpwhpro/webhooks/trigger_create_comment_results', $data_array, $comment, $comment_id );			
 					$response_data[] = WPWHPRO()->webhook->post_to_webhook( $webhook, $data_array );
 				}
 			}


### PR DESCRIPTION
# Overview
The goal of this PR is to add filters to the create comment results. These filters can be used to modify the result sent via webhook.

# Our use case
 * We're using `wp-graphql` as a backend for a mobile app
 * `wp-webhooks` allows us to send webhooks when comments are created

Filtering the post result allows us to send graphql IDs to the app to allow it to to look up the notification post and parent comment via our `wp-graphql` endpoint. 